### PR TITLE
Added opssibility to specify storage engine to in the test database, …

### DIFF
--- a/mongobox/__init__.py
+++ b/mongobox/__init__.py
@@ -3,9 +3,3 @@ from .mongobox import MongoBox
 
 __author__ = 'Roman Kalyakin <roman@kalyakin.com>'
 __version__ = '0.1.7'
-
-__all__ = [
-    'MongoBox',
-    '__version__',
-    '__author__'
-]

--- a/mongobox/__init__.py
+++ b/mongobox/__init__.py
@@ -2,7 +2,7 @@
 from .mongobox import MongoBox
 
 __author__ = 'Roman Kalyakin <roman@kalyakin.com>'
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 
 __all__ = [
     'MongoBox',

--- a/mongobox/nose2_plugin.py
+++ b/mongobox/nose2_plugin.py
@@ -17,6 +17,9 @@ nose2.cfg should contain:
     # logpath =
     # Optionally preallocate db files
     # prealloc = True
+    # Specify storage engine to use
+    # https://docs.mongodb.org/manual/release-notes/3.2-compatibility/#default-storage-engine-change
+    # storage_engine =
     # Which environment variable port number will be exported to
     port_envvar = MONGOBOX_PORT
 
@@ -49,6 +52,7 @@ class MongoBoxPlugin(nose2.events.Plugin):
             db_path=self.config.get('dbpath'),
             scripting=self.config.as_bool('scripting', False),
             prealloc=self.config.as_bool('prealloc', False),
+            storage_engine=self.config.get('storage_engine'),
         )
         self.port_envvar = self.config.get('port_envvar', DEFAULT_PORT_ENVVAR)
 

--- a/mongobox/nose2_plugin.py
+++ b/mongobox/nose2_plugin.py
@@ -48,7 +48,6 @@ class MongoBoxPlugin(nose2.events.Plugin):
         self.mongobox = MongoBox(
             mongod_bin=self.config.get('bin'),
             port=self.config.as_int('port'),
-            log_path=self.config.get('logpath'),
             db_path=self.config.get('dbpath'),
             scripting=self.config.as_bool('scripting', False),
             prealloc=self.config.as_bool('prealloc', False),

--- a/mongobox/nose_plugin.py
+++ b/mongobox/nose_plugin.py
@@ -42,12 +42,6 @@ class MongoBoxPlugin(Plugin):
             default=None,
             help=("Path to database files directory. Creates temporary directory by default."))
         parser.add_option(
-            "--mongobox-logpath",
-            action="store",
-            dest="logpath",
-            default=None,
-            help=("Optionally store the mongodb log here (default is /dev/null)"))
-        parser.add_option(
             "--mongobox-prealloc",
             action="store_true",
             dest="prealloc",
@@ -80,7 +74,7 @@ class MongoBoxPlugin(Plugin):
 
         self.mongobox = MongoBox(
             mongod_bin=options.bin, port=options.port or None,
-            log_path=options.logpath, db_path=options.dbpath,
+            db_path=options.dbpath,
             scripting=options.scripting, prealloc=options.prealloc,
             storage_engine=options.storage_engine,
         )

--- a/mongobox/nose_plugin.py
+++ b/mongobox/nose_plugin.py
@@ -65,6 +65,12 @@ class MongoBoxPlugin(Plugin):
             dest="auth",
             default=False,
             help="Enable mongodb's user authentication mechanisms.")
+        parser.add_option(
+            "--mongobox-storage-engine",
+            action="store",
+            dest="storage_engine",
+            default=None,
+            help=("Storage engine to use."))
 
     def configure(self, options, conf):
         super(MongoBoxPlugin, self).configure(options, conf)
@@ -75,7 +81,8 @@ class MongoBoxPlugin(Plugin):
         self.mongobox = MongoBox(
             mongod_bin=options.bin, port=options.port or None,
             log_path=options.logpath, db_path=options.dbpath,
-            scripting=options.scripting, prealloc=options.prealloc
+            scripting=options.scripting, prealloc=options.prealloc,
+            storage_engine=options.storage_engine,
         )
 
         self.port_envvar = options.port_envvar

--- a/mongobox/utils.py
+++ b/mongobox/utils.py
@@ -12,6 +12,10 @@ def find_executable(executable):
         if os.path.isfile(executable_path):
             return executable_path
 
+    raise AssertionError('Could not find "{}" in system PATH. Make sure you have it installed.'.format(
+        executable))
+
+
 def get_free_port(host="localhost"):
     """Get a free port on the machine.
     """


### PR DESCRIPTION
…because WiredTiger which is the default storage engine in MongoDB 3.2 proved to be about 4 times slower then MMAPv1 which was used in prev. versions of MongoDB.
http://stackoverflow.com/a/36998832/248296
