### PR TITLE
mongod --nohttpinterface option is deprecated

### DIFF
--- a/mongobox/mongobox.py
+++ b/mongobox/mongobox.py
@@ -15,8 +15,6 @@ MONGOD_BIN = 'mongod'
 DEFAULT_ARGS = [
     # don't flood stdout, we're not reading it
     "--quiet",
-    # save the port
-    "--nohttpinterface",
     # disable unused.
     "--nounixsocket",
     # use a smaller default file size


### PR DESCRIPTION
Since MongoDB version 2.6 the http interface is disabled by default and therefore --nohttpinterface option is deprecated. See mongod man pages and MongoDB release notes: https://docs.mongodb.com/manual/release-notes/2.6/

The option prevents mongod starting and MongoBox().start() will fail:
```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    mongobox.MongoBox().start()
  File "/home/vagrant/scratch/access-rest-api/venv/lib/python2.7/site-packages/mongobox/mongobox.py", line 89, in start
    return self._wait_till_started()
  File "/home/vagrant/scratch/access-rest-api/venv/lib/python2.7/site-packages/mongobox/mongobox.py", line 134, in _wait_till_started
    self.stop()
  File "/home/vagrant/scratch/access-rest-api/venv/lib/python2.7/site-packages/mongobox/mongobox.py", line 100, in stop
    os.kill(self.process.pid, 9)
OSError: [Errno 3] No such process
```
Tested on mongod version v3.6.8.
